### PR TITLE
Framerate Safety

### DIFF
--- a/SamplePlugin/HighFpsPhysicsPlugin.csproj
+++ b/SamplePlugin/HighFpsPhysicsPlugin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Authors>ItsLunaYup</Authors>
-    <Version>9.0.0.0</Version>
+    <Version>9.0.0.1</Version>
     <Description>Simple plugin that divides the physics' refresh rate, making physics (kinda) work at high fps.</Description>
     <PackageProjectUrl>https://github.com/ItsLunaYup/xivlauncher_physics_plugin</PackageProjectUrl>
 

--- a/SamplePlugin/PluginUI.cs
+++ b/SamplePlugin/PluginUI.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System;
+using System.Numerics;
 using Dalamud.Interface.Windowing;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
@@ -66,7 +67,7 @@ internal class ConfigurationWindow : Window
         var target_fps = Service.Settings.TargetFPS;
         if (ImGui.SliderFloat("Physics FPS", ref target_fps, 1, 120))
         {
-            Service.Settings.TargetFPS = target_fps;
+            Service.Settings.TargetFPS = Math.Clamp(target_fps, 1, 240);
             Service.Settings.Save();
             Service.PhysicsModification.RecalculateExpectedFrametime();
         }


### PR DESCRIPTION
When double clicking the slider element, the user can input any value they want, this allows you to set 0, which will freeze and then crash the game, and will cause repeated freezing and crashing on subsequent relaunches.

This PR claps the values between 1 and 240 (donno why you would want to go over 60, but alas it doesn't hurt to set the upper limit to 240)